### PR TITLE
Concat Mutation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
     -   repo: https://github.com/ambv/black
-        rev: stable
+        rev: 20.8b1
         hooks:
         - id: black
           language_version: python3.7
     -   repo: https://gitlab.com/pycqa/flake8
-        rev: 3.7.9
+        rev: 3.8.4
         hooks:
         - id: flake8

--- a/py_linq/py_linq.py
+++ b/py_linq/py_linq.py
@@ -84,8 +84,7 @@ class Enumerable(object):
         :param func: lambda expression on how to perform transformation
         :return: new Enumerable object containing transformed data
         """
-        self._iterable = SelectEnumerable(Enumerable(iter(self)), func)
-        return self
+        return SelectEnumerable(Enumerable(iter(self)), func)
 
     def sum(self, func=lambda x: x):
         """
@@ -222,9 +221,7 @@ class Enumerable(object):
         if key is None:
             raise NullArgumentError(u"No key for sorting given")
         kf = [OrderingDirection(key, reverse=False)]
-        sorted = SortedEnumerable(Enumerable(iter(self)), key_funcs=kf)
-        self._iterable = sorted
-        return sorted
+        return SortedEnumerable(Enumerable(iter(self)), key_funcs=kf)
 
     def order_by_descending(self, key):
         """
@@ -235,9 +232,7 @@ class Enumerable(object):
         if key is None:
             raise NullArgumentError(u"No key for sorting given")
         kf = [OrderingDirection(key, reverse=True)]
-        sorted = SortedEnumerable(Enumerable(iter(self)), key_funcs=kf)
-        self._iterable = sorted
-        return sorted
+        return SortedEnumerable(Enumerable(iter(self)), key_funcs=kf)
 
     def skip(self, n):
         """
@@ -245,8 +240,7 @@ class Enumerable(object):
         :param n: Number of elements to skip as int
         :return: new Enumerable object
         """
-        self._iterable = SkipEnumerable(Enumerable(iter(self)), n)
-        return self
+        return SkipEnumerable(Enumerable(iter(self)), n)
 
     def take(self, n):
         """
@@ -254,8 +248,7 @@ class Enumerable(object):
         :param n: Number of elements to take
         :return: new Enumerable object
         """
-        self._iterable = TakeEnumerable(Enumerable(iter(self)), n)
-        return self
+        return TakeEnumerable(Enumerable(iter(self)), n)
 
     def where(self, predicate):
         """
@@ -265,8 +258,7 @@ class Enumerable(object):
         """
         if predicate is None:
             raise NullArgumentError("No predicate given for where clause")
-        self._iterable = WhereEnumerable(Enumerable(iter(self)), predicate)
-        return self
+        return WhereEnumerable(Enumerable(iter(self)), predicate)
 
     def single(self, predicate=None):
         """
@@ -306,8 +298,7 @@ class Enumerable(object):
         :param func: selector as lambda expression
         :return: new Enumerable object
         """
-        self._iterable = SelectManyEnumerable(Enumerable(iter(self)), func)
-        return self
+        return SelectManyEnumerable(Enumerable(iter(self)), func)
 
     def add(self, element):
         """
@@ -327,8 +318,9 @@ class Enumerable(object):
         """
         if not isinstance(enumerable, Enumerable):
             raise TypeError(u"enumerable argument must be an instance of Enumerable")
-        self._iterable = ConcatenateEnumerable(Enumerable(iter(self)), enumerable)
-        return self
+        concatenated = ConcatenateEnumerable(Enumerable(iter(self)), enumerable)
+        self._iterable = concatenated
+        return concatenated
 
     def group_by(self, key_names=[], key=lambda x: x, result_func=lambda x: x):
         """
@@ -363,10 +355,7 @@ class Enumerable(object):
         :param result_func: transformation function as lambda expression
         :return: Enumerable of grouping objects
         """
-        self._iterable = GroupedEnumerable(
-            Enumerable(iter(self)), key, key_names, result_func
-        )
-        return self
+        return GroupedEnumerable(Enumerable(iter(self)), key, key_names, result_func)
 
     def distinct(self, key=lambda x: x):
         """
@@ -375,10 +364,9 @@ class Enumerable(object):
         :param key: key selector as lambda expression
         :return: new Enumerable object
         """
-        self._iterable = GroupedEnumerable(
+        return GroupedEnumerable(
             Enumerable(iter(self)), key, ["distinct"], lambda g: g.first()
         )
-        return self
 
     def join(
         self,
@@ -399,10 +387,9 @@ class Enumerable(object):
             raise TypeError(
                 u"inner_enumerable parameter must be an instance of Enumerable"
             )
-        self._iterable = JoinEnumerable(
+        return JoinEnumerable(
             Enumerable(iter(self)), inner_enumerable, outer_key, inner_key, result_func
         )
-        return self
 
     def default_if_empty(self, value=None):
         """
@@ -454,8 +441,7 @@ class Enumerable(object):
             )
             .select(lambda gj: result_func(gj))
         )
-        self._iterable = group_joined
-        return self
+        return group_joined
 
     def any(self, predicate=None):
         """
@@ -475,8 +461,7 @@ class Enumerable(object):
         """
         if not isinstance(enumerable, Enumerable):
             raise TypeError(u"enumerable parameter must be an instance of Enumerable")
-        self._iterable = IntersectEnumerable(Enumerable(iter(self)), enumerable, key)
-        return self
+        return IntersectEnumerable(Enumerable(iter(self)), enumerable, key)
 
     def aggregate(self, func, seed=None):
         """
@@ -586,8 +571,7 @@ class Enumerable(object):
         Inverts the order of the elements in a sequence
         :return: Enumerable with elements in reversed order
         """
-        self._iterable = ReversedEnumerable(Enumerable(iter(self)))
-        return self
+        return ReversedEnumerable(Enumerable(iter(self)))
 
     def skip_last(self, n):
         """
@@ -604,8 +588,7 @@ class Enumerable(object):
         :param predicate: a predicate as a lambda expression
         :return: Enumerable
         """
-        self._iterable = SkipWhileEnumerable(Enumerable(iter(self)), predicate)
-        return self
+        return SkipWhileEnumerable(Enumerable(iter(self)), predicate)
 
     def take_last(self, n):
         """
@@ -622,8 +605,7 @@ class Enumerable(object):
         :param predicate: a predicate as a lambda expression
         :return: Enumerable
         """
-        self._iterable = TakeWhileEnumerable(Enumerable(iter(self)), predicate)
-        return self
+        return TakeWhileEnumerable(Enumerable(iter(self)), predicate)
 
     def zip(self, enumerable, func=lambda x: x):
         """
@@ -635,8 +617,7 @@ class Enumerable(object):
         """
         if not isinstance(enumerable, Enumerable):
             raise TypeError()
-        self._iterable = ZipEnumerable(Enumerable(iter(self)), enumerable, func)
-        return self
+        return ZipEnumerable(Enumerable(iter(self)), enumerable, func)
 
 
 class SelectEnumerable(Enumerable):
@@ -937,9 +918,7 @@ class SortedEnumerable(Enumerable):
         if func is None:
             raise NullArgumentError(u"then by requires a lambda function arg")
         self._key_funcs.append(OrderingDirection(key=func, reverse=False))
-        sorted = SortedEnumerable(self, self._key_funcs)
-        self._iterable = sorted
-        return self
+        return SortedEnumerable(self, self._key_funcs)
 
     def then_by_descending(self, func):
         """
@@ -952,9 +931,7 @@ class SortedEnumerable(Enumerable):
                 u"then_by_descending requires a lambda function arg"
             )
         self._key_funcs.append(OrderingDirection(key=func, reverse=True))
-        sorted = SortedEnumerable(self, self._key_funcs)
-        self._iterable = sorted
-        return self
+        return SortedEnumerable(self, self._key_funcs)
 
 
 class ZipEnumerable(Enumerable):

--- a/py_linq/py_linq.py
+++ b/py_linq/py_linq.py
@@ -84,7 +84,8 @@ class Enumerable(object):
         :param func: lambda expression on how to perform transformation
         :return: new Enumerable object containing transformed data
         """
-        return SelectEnumerable(self, func)
+        self._iterable = SelectEnumerable(Enumerable(iter(self)), func)
+        return self
 
     def sum(self, func=lambda x: x):
         """
@@ -221,7 +222,9 @@ class Enumerable(object):
         if key is None:
             raise NullArgumentError(u"No key for sorting given")
         kf = [OrderingDirection(key, reverse=False)]
-        return SortedEnumerable(self, key_funcs=kf)
+        sorted = SortedEnumerable(Enumerable(iter(self)), key_funcs=kf)
+        self._iterable = sorted
+        return sorted
 
     def order_by_descending(self, key):
         """
@@ -232,7 +235,9 @@ class Enumerable(object):
         if key is None:
             raise NullArgumentError(u"No key for sorting given")
         kf = [OrderingDirection(key, reverse=True)]
-        return SortedEnumerable(self, key_funcs=kf)
+        sorted = SortedEnumerable(Enumerable(iter(self)), key_funcs=kf)
+        self._iterable = sorted
+        return sorted
 
     def skip(self, n):
         """
@@ -240,7 +245,8 @@ class Enumerable(object):
         :param n: Number of elements to skip as int
         :return: new Enumerable object
         """
-        return SkipEnumerable(self, n)
+        self._iterable = SkipEnumerable(Enumerable(iter(self)), n)
+        return self
 
     def take(self, n):
         """
@@ -248,7 +254,8 @@ class Enumerable(object):
         :param n: Number of elements to take
         :return: new Enumerable object
         """
-        return TakeEnumerable(self, n)
+        self._iterable = TakeEnumerable(Enumerable(iter(self)), n)
+        return self
 
     def where(self, predicate):
         """
@@ -258,7 +265,8 @@ class Enumerable(object):
         """
         if predicate is None:
             raise NullArgumentError("No predicate given for where clause")
-        return WhereEnumerable(self, predicate)
+        self._iterable = WhereEnumerable(Enumerable(iter(self)), predicate)
+        return self
 
     def single(self, predicate=None):
         """
@@ -298,7 +306,8 @@ class Enumerable(object):
         :param func: selector as lambda expression
         :return: new Enumerable object
         """
-        return SelectManyEnumerable(self, func)
+        self._iterable = SelectManyEnumerable(Enumerable(iter(self)), func)
+        return self
 
     def add(self, element):
         """
@@ -318,7 +327,8 @@ class Enumerable(object):
         """
         if not isinstance(enumerable, Enumerable):
             raise TypeError(u"enumerable argument must be an instance of Enumerable")
-        return ConcatenateEnumerable(self, enumerable)
+        self._iterable = ConcatenateEnumerable(Enumerable(iter(self)), enumerable)
+        return self
 
     def group_by(self, key_names=[], key=lambda x: x, result_func=lambda x: x):
         """
@@ -353,7 +363,10 @@ class Enumerable(object):
         :param result_func: transformation function as lambda expression
         :return: Enumerable of grouping objects
         """
-        return GroupedEnumerable(self, key, key_names, result_func)
+        self._iterable = GroupedEnumerable(
+            Enumerable(iter(self)), key, key_names, result_func
+        )
+        return self
 
     def distinct(self, key=lambda x: x):
         """
@@ -362,7 +375,10 @@ class Enumerable(object):
         :param key: key selector as lambda expression
         :return: new Enumerable object
         """
-        return GroupedEnumerable(self, key, ["distinct"], lambda g: g.first())
+        self._iterable = GroupedEnumerable(
+            Enumerable(iter(self)), key, ["distinct"], lambda g: g.first()
+        )
+        return self
 
     def join(
         self,
@@ -383,7 +399,10 @@ class Enumerable(object):
             raise TypeError(
                 u"inner_enumerable parameter must be an instance of Enumerable"
             )
-        return JoinEnumerable(self, inner_enumerable, outer_key, inner_key, result_func)
+        self._iterable = JoinEnumerable(
+            Enumerable(iter(self)), inner_enumerable, outer_key, inner_key, result_func
+        )
+        return self
 
     def default_if_empty(self, value=None):
         """
@@ -415,9 +434,28 @@ class Enumerable(object):
             raise TypeError(
                 u"inner enumerable parameter must be an instance of Enumerable"
             )
-        return GroupJoinEnumerable(
-            self, inner_enumerable, outer_key, inner_key, result_func
+        group_joined = (
+            Enumerable(iter(self))
+            .join(
+                inner_enumerable=inner_enumerable,
+                outer_key=outer_key,
+                inner_key=inner_key,
+                result_func=lambda e: (e[0], e[1]),
+            )
+            .group_by(
+                key_names=["id"],
+                key=lambda t: outer_key(t[0]),
+                result_func=lambda g: (
+                    g.first()[0],
+                    g.where(lambda i: inner_key(i[1]) == g.key.id).select(
+                        lambda i: i[1]
+                    ),
+                ),
+            )
+            .select(lambda gj: result_func(gj))
         )
+        self._iterable = group_joined
+        return self
 
     def any(self, predicate=None):
         """
@@ -437,7 +475,8 @@ class Enumerable(object):
         """
         if not isinstance(enumerable, Enumerable):
             raise TypeError(u"enumerable parameter must be an instance of Enumerable")
-        return IntersectEnumerable(self, enumerable, key)
+        self._iterable = IntersectEnumerable(Enumerable(iter(self)), enumerable, key)
+        return self
 
     def aggregate(self, func, seed=None):
         """
@@ -467,7 +506,7 @@ class Enumerable(object):
         """
         if not isinstance(enumerable, Enumerable):
             raise TypeError(u"enumerable parameter must be an instance of Enumerable")
-        return UnionEnumerable(self, enumerable, key)
+        return UnionEnumerable(Enumerable(iter(self)), enumerable, key)
 
     def except_(self, enumerable, key=lambda x: x):
         """
@@ -478,7 +517,7 @@ class Enumerable(object):
         """
         if not isinstance(enumerable, Enumerable):
             raise TypeError(u"enumerable parameter must be an instance of Enumerable")
-        return ExceptEnumerable(self, enumerable, key)
+        return ExceptEnumerable(Enumerable(iter(self)), enumerable, key)
 
     def contains(self, element, key=lambda x: x):
         """
@@ -547,7 +586,8 @@ class Enumerable(object):
         Inverts the order of the elements in a sequence
         :return: Enumerable with elements in reversed order
         """
-        return ReversedEnumerable(self)
+        self._iterable = ReversedEnumerable(Enumerable(iter(self)))
+        return self
 
     def skip_last(self, n):
         """
@@ -564,7 +604,8 @@ class Enumerable(object):
         :param predicate: a predicate as a lambda expression
         :return: Enumerable
         """
-        return SkipWhileEnumerable(self, predicate)
+        self._iterable = SkipWhileEnumerable(Enumerable(iter(self)), predicate)
+        return self
 
     def take_last(self, n):
         """
@@ -581,7 +622,8 @@ class Enumerable(object):
         :param predicate: a predicate as a lambda expression
         :return: Enumerable
         """
-        return TakeWhileEnumerable(self, predicate)
+        self._iterable = TakeWhileEnumerable(Enumerable(iter(self)), predicate)
+        return self
 
     def zip(self, enumerable, func=lambda x: x):
         """
@@ -593,7 +635,8 @@ class Enumerable(object):
         """
         if not isinstance(enumerable, Enumerable):
             raise TypeError()
-        return ZipEnumerable(self, enumerable, func)
+        self._iterable = ZipEnumerable(Enumerable(iter(self)), enumerable, func)
+        return self
 
 
 class SelectEnumerable(Enumerable):
@@ -728,7 +771,10 @@ class ConcatenateEnumerable(Enumerable):
         self.enumerable = enumerable2
 
     def __iter__(self):
-        return itertools.chain(iter(self._iterable), self.enumerable)
+        for i in iter(self._iterable):
+            yield i
+        for j in iter(self.enumerable):
+            yield j
 
     def __getitem__(self, n):
         if n < 0:
@@ -891,7 +937,9 @@ class SortedEnumerable(Enumerable):
         if func is None:
             raise NullArgumentError(u"then by requires a lambda function arg")
         self._key_funcs.append(OrderingDirection(key=func, reverse=False))
-        return SortedEnumerable(self, self._key_funcs)
+        sorted = SortedEnumerable(self, self._key_funcs)
+        self._iterable = sorted
+        return self
 
     def then_by_descending(self, func):
         """
@@ -904,7 +952,9 @@ class SortedEnumerable(Enumerable):
                 u"then_by_descending requires a lambda function arg"
             )
         self._key_funcs.append(OrderingDirection(key=func, reverse=True))
-        return SortedEnumerable(self, self._key_funcs)
+        sorted = SortedEnumerable(self, self._key_funcs)
+        self._iterable = sorted
+        return self
 
 
 class ZipEnumerable(Enumerable):
@@ -965,32 +1015,3 @@ class JoinEnumerable(Enumerable):
                 ik = self.inner_key(inner)
                 if ok == ik:
                     yield self.result_func((outer, inner))
-
-
-class GroupJoinEnumerable(Enumerable):
-    """
-    Class to hold state for performing group join
-    """
-
-    def __init__(
-        self, outer_enumerable, inner_enumerable, outer_key, inner_key, result_func
-    ):
-        super(GroupJoinEnumerable, self).__init__(outer_enumerable)
-        self.inner_enumerable = inner_enumerable
-        self.outer_key = outer_key
-        self.inner_key = inner_key
-        self.result_func = result_func
-
-    def __iter__(self):
-        for o in iter(self._iterable):
-            ok = self.outer_key(o)
-            result = self.result_func(
-                (
-                    o,
-                    Grouping(
-                        Key({"id": ok}),
-                        self.inner_enumerable.where(lambda i: self.inner_key(i) == ok),
-                    ),
-                )
-            )
-            yield result

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,3 +1,4 @@
+from py_linq.py_linq import SelectEnumerable, WhereEnumerable
 from unittest import TestCase
 from py_linq import Enumerable
 from tests import _empty, _simple, _complex, _locations
@@ -73,17 +74,25 @@ class TestFunctions(TestCase):
         self.assertEqual(self.complex.count(lambda x: x["value"] > 1), 2)
 
     def test_select(self):
-        self.assertListEqual([], self.empty.select(lambda x: x["value"]).to_list())
+        self.assertListEqual(
+            [], Enumerable.empty().select(lambda x: x["value"]).to_list()
+        )
         self.assertListEqual(
             [{"value": 1}, {"value": 2}, {"value": 3}],
-            self.simple.select(lambda x: {"value": x}).to_list(),
+            Enumerable([1, 2, 3]).select(lambda x: {"value": x}).to_list(),
         )
         self.assertListEqual(
-            [1, 2, 3], self.complex.select(lambda x: x["value"]).to_list()
+            [1, 2, 3],
+            Enumerable(
+                [
+                    {"value": 1},
+                    {"value": 2},
+                    {"value": 3},
+                ]
+            )
+            .select(lambda x: x["value"])
+            .to_list(),
         )
-
-        for i, e in enumerate(self.complex.select(lambda x: x["value"])):
-            self.assertEqual(i + 1, e)
 
     def test_min(self):
         self.assertRaises(NoElementsError, self.empty.min)
@@ -192,9 +201,9 @@ class TestFunctions(TestCase):
         self.assertEqual(median, self.complex.median(lambda x: x["value"]))
 
     def test_skip(self):
-        self.assertListEqual([], self.empty.skip(2).to_list())
-        self.assertListEqual([], self.simple.skip(3).to_list())
-        self.assertListEqual([2, 3], self.simple.skip(1).to_list())
+        self.assertListEqual([], Enumerable().skip(2).to_list())
+        self.assertListEqual([], Enumerable([1, 2, 3]).skip(3).to_list())
+        self.assertListEqual([2, 3], Enumerable([1, 2, 3]).skip(1).to_list())
 
     def test_take(self):
         self.assertListEqual(_simple, self.simple.take(4).to_list())
@@ -218,7 +227,8 @@ class TestFunctions(TestCase):
     def test_select_with_filter(self):
         self.assertListEqual(
             [2],
-            self.complex.where(lambda x: x["value"] == 2)
+            Enumerable([{"value": 1}, {"value": 2}, {"value": 3}])
+            .where(lambda x: x["value"] == 2)
             .select(lambda x: x["value"])
             .to_list(),
         )
@@ -268,53 +278,138 @@ class TestFunctions(TestCase):
         )
 
     def test_select_many(self):
-        empty = Enumerable([[], [], []])
-        simple = Enumerable([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-        __complex = Enumerable(
-            [
-                {"key": 1, "values": [1, 2, 3]},
-                {"key": 2, "values": [4, 5, 6]},
-                {"key": 3, "values": [7, 8, 9]},
-            ]
-        )
-
-        self.assertListEqual([], empty.select_many().to_list())
-        self.assertListEqual(
-            [1, 2, 3, 4, 5, 6, 7, 8, 9], simple.select_many().to_list()
-        )
-        self.assertEqual(9, simple.select_many().count())
+        self.assertListEqual([], Enumerable([[], [], []]).select_many().to_list())
         self.assertListEqual(
             [1, 2, 3, 4, 5, 6, 7, 8, 9],
-            __complex.select_many(lambda x: x["values"]).to_list(),
+            Enumerable([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).select_many().to_list(),
         )
-        self.assertEqual(9, __complex.select_many(lambda x: x["values"]).count())
+        self.assertEqual(
+            9, Enumerable([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).select_many().count()
+        )
+        self.assertListEqual(
+            [1, 2, 3, 4, 5, 6, 7, 8, 9],
+            Enumerable(
+                [
+                    {"key": 1, "values": [1, 2, 3]},
+                    {"key": 2, "values": [4, 5, 6]},
+                    {"key": 3, "values": [7, 8, 9]},
+                ]
+            )
+            .select_many(lambda x: x["values"])
+            .to_list(),
+        )
+        self.assertEqual(
+            9,
+            Enumerable(
+                [
+                    {"key": 1, "values": [1, 2, 3]},
+                    {"key": 2, "values": [4, 5, 6]},
+                    {"key": 3, "values": [7, 8, 9]},
+                ]
+            )
+            .select_many(lambda x: x["values"])
+            .count(),
+        )
 
     def test_concat(self):
-        self.assertListEqual([], self.empty.concat(self.empty).to_list())
-        self.assertListEqual(_simple, self.empty.concat(self.simple).to_list())
-        self.assertListEqual(_simple, self.simple.concat(self.empty).to_list())
+        self.assertListEqual([], Enumerable().concat(Enumerable()).to_list())
+        self.assertListEqual([1, 2, 3], self.empty.concat(self.simple).to_list())
+        self.assertListEqual([1, 2, 3], self.simple.concat(Enumerable()).to_list())
         self.assertListEqual(
             [1, 2, 3, 1, 2, 3],
-            self.simple.concat(self.complex.select(lambda c: c["value"])).to_list(),
+            Enumerable([1, 2, 3])
+            .concat(
+                Enumerable(
+                    [
+                        {"value": 1},
+                        {"value": 2},
+                        {"value": 3},
+                    ]
+                ).select(lambda c: c["value"])
+            )
+            .to_list(),
         )
         self.assertListEqual(
             [1, 2, 3, 1, 2, 3],
-            self.complex.select(lambda c: c["value"]).concat(self.simple).to_list(),
+            Enumerable(
+                [
+                    {"value": 1},
+                    {"value": 2},
+                    {"value": 3},
+                ]
+            )
+            .select(lambda c: c["value"])
+            .concat(Enumerable([1, 2, 3]))
+            .to_list(),
         )
         self.assertListEqual(
             [1, 2, 3, {"value": 1}, {"value": 2}, {"value": 3}],
-            self.simple.concat(self.complex).to_list(),
+            Enumerable([1, 2, 3])
+            .concat(
+                Enumerable(
+                    [
+                        {"value": 1},
+                        {"value": 2},
+                        {"value": 3},
+                    ]
+                )
+            )
+            .to_list(),
         )
 
+    def test_concat_mutating(self):
+        empty = Enumerable()
+        empty.concat(Enumerable())
+        self.assertListEqual([], empty.to_list())
+
+        simple = Enumerable()
+        simple.concat(Enumerable([1, 2, 3]))
+        self.assertListEqual([1, 2, 3], simple.to_list())
+
+        double_simple = Enumerable([1, 2, 3])
+        double_simple.concat(
+            Enumerable(
+                [
+                    {"value": 1},
+                    {"value": 2},
+                    {"value": 3},
+                ]
+            ).select(lambda c: c["value"])
+        )
+        self.assertListEqual([1, 2, 3, 1, 2, 3], double_simple.to_list())
+
+        simple_complex = Enumerable([1, 2, 3])
+        simple_complex.concat(
+            Enumerable(
+                [
+                    {"value": 1},
+                    {"value": 2},
+                    {"value": 3},
+                ]
+            )
+        )
+        self.assertListEqual(
+            [1, 2, 3, {"value": 1}, {"value": 2}, {"value": 3}],
+            simple_complex.to_list(),
+        )
+
+    def test_multiple_concatenate(self):
+        simple = Enumerable([1, 2, 3])
+        simple.add(4)
+        self.assertEqual(4, simple.count())
+        simple.add(5)
+        self.assertEqual(5, simple.count())
+        self.assertEqual(5, simple.last())
+
     def test_group_by(self):
-        simple_grouped = self.simple.group_by(key_names=["id"])
+        simple_grouped = Enumerable([1, 2, 3]).group_by(key_names=["id"])
         self.assertEqual(3, simple_grouped.count())
         second = simple_grouped.single(lambda s: s.key.id == 2)
         self.assertListEqual([2], second.to_list())
 
-        complex_grouped = self.complex.group_by(
-            key_names=["value"], key=lambda x: x["value"]
-        )
+        complex_grouped = Enumerable(
+            [{"value": 1}, {"value": 2}, {"value": 3}]
+        ).group_by(key_names=["value"], key=lambda x: x["value"])
         self.assertEqual(complex_grouped.count(), 3)
         self.assertListEqual(
             [1, 2, 3],
@@ -334,9 +429,11 @@ class TestFunctions(TestCase):
         self.assertEqual(240000, london.sum(lambda c: c[3]))
 
     def test_distinct(self):
-        self.assertListEqual([], self.empty.distinct().to_list())
+        self.assertListEqual([], Enumerable.empty().distinct().to_list())
         six.assertCountEqual(
-            self, _simple, self.simple.concat(self.simple).distinct().to_list()
+            self,
+            [1, 2, 3],
+            Enumerable([1, 2, 3]).concat(Enumerable([1, 2, 3])).distinct().to_list(),
         )
 
         locations = Enumerable(_locations).distinct(lambda x: x[0])
@@ -348,15 +445,23 @@ class TestFunctions(TestCase):
         six.assertCountEqual(self, _complex, self.complex.default_if_empty().to_list())
 
     def test_any(self):
-        self.assertFalse(self.empty.any(lambda x: x == 1))
-        self.assertFalse(self.empty.any())
+        self.assertFalse(Enumerable.empty().any(lambda x: x == 1))
+        self.assertFalse(Enumerable.empty().any())
 
-        self.assertTrue(self.simple.any(lambda x: x == 1))
-        self.assertTrue(self.simple.any())
+        self.assertTrue(Enumerable([1, 2, 3]).any(lambda x: x == 1))
+        self.assertTrue(Enumerable([1, 2, 3]).any())
 
-        self.assertTrue(self.complex.any())
-        self.assertFalse(self.complex.any(lambda x: x["value"] < 1))
-        self.assertTrue(self.complex.any(lambda x: x["value"] >= 1))
+        self.assertTrue(Enumerable([{"value": 1}, {"value": 2}, {"value": 3}]).any())
+        self.assertFalse(
+            Enumerable([{"value": 1}, {"value": 2}, {"value": 3}]).any(
+                lambda x: x["value"] < 1
+            )
+        )
+        self.assertTrue(
+            Enumerable([{"value": 1}, {"value": 2}, {"value": 3}]).any(
+                lambda x: x["value"] >= 1
+            )
+        )
 
     def test_contains(self):
         self.assertFalse(self.empty.contains(1))
@@ -364,15 +469,66 @@ class TestFunctions(TestCase):
         self.assertTrue(self.complex.select(lambda x: x["value"]).contains(1))
 
     def test_intersect(self):
-        self.assertRaises(TypeError, self.empty.intersect, [])
-        self.assertListEqual(self.empty.intersect(self.empty).to_list(), [])
-        self.assertListEqual(self.empty.intersect(self.simple).to_list(), [])
-        self.assertListEqual(self.simple.intersect(self.simple).to_list(), _simple)
-        self.assertListEqual(self.simple.intersect(Enumerable([2])).to_list(), [2])
-        self.assertListEqual(self.simple.intersect(self.complex).to_list(), [])
-        self.assertListEqual(self.complex.intersect(self.complex).to_list(), _complex)
+        self.assertRaises(TypeError, Enumerable.empty().intersect, [])
+        self.assertListEqual([], Enumerable().intersect(Enumerable.empty()).to_list())
         self.assertListEqual(
-            self.complex.intersect(Enumerable([{"value": 1}])).to_list(), [{"value": 1}]
+            [], Enumerable.empty().intersect(Enumerable([1, 2, 3])).to_list()
+        )
+        self.assertListEqual(
+            [1, 2, 3], Enumerable([1, 2, 3]).intersect(Enumerable([1, 2, 3])).to_list()
+        )
+        self.assertListEqual(
+            [2], Enumerable([1, 2, 3]).intersect(Enumerable([2])).to_list()
+        )
+        self.assertListEqual(
+            [],
+            Enumerable([1, 2, 3])
+            .intersect(
+                Enumerable(
+                    [
+                        {"value": 1},
+                        {"value": 2},
+                        {"value": 3},
+                    ]
+                )
+            )
+            .to_list(),
+        )
+        self.assertListEqual(
+            [
+                {"value": 1},
+                {"value": 2},
+                {"value": 3},
+            ],
+            Enumerable(
+                [
+                    {"value": 1},
+                    {"value": 2},
+                    {"value": 3},
+                ]
+            )
+            .intersect(
+                Enumerable(
+                    [
+                        {"value": 1},
+                        {"value": 2},
+                        {"value": 3},
+                    ]
+                )
+            )
+            .to_list(),
+        )
+        self.assertListEqual(
+            Enumerable(
+                [
+                    {"value": 1},
+                    {"value": 2},
+                    {"value": 3},
+                ]
+            )
+            .intersect(Enumerable([{"value": 1}]))
+            .to_list(),
+            [{"value": 1}],
         )
 
     def test_except(self):
@@ -464,20 +620,28 @@ class TestFunctions(TestCase):
         )
 
     def test_join(self):
-        self.assertRaises(TypeError, self.empty.join, [])
-        self.assertListEqual([], self.empty.join(self.empty).to_list())
-        self.assertListEqual([], self.empty.join(self.simple).to_list())
-        self.assertListEqual([], self.empty.join(self.complex).to_list())
+        self.assertRaises(TypeError, Enumerable.empty().join, [])
+        self.assertListEqual([], Enumerable().join(Enumerable()).to_list())
+        self.assertListEqual([], Enumerable().join(Enumerable([1, 2, 3])).to_list())
+        self.assertListEqual(
+            [],
+            Enumerable()
+            .join(Enumerable([{"value": 1}, {"value": 2}, {"value": 3}]))
+            .to_list(),
+        )
 
-        self.assertListEqual([], self.simple.join(self.empty).to_list())
         self.assertListEqual(
             [(1, 1), (2, 2), (3, 3)],
-            self.simple.join(self.simple).order_by(lambda x: (x[0], x[1])).to_list(),
+            Enumerable([1, 2, 3])
+            .join(Enumerable([1, 2, 3]))
+            .order_by(lambda x: (x[0], x[1]))
+            .to_list(),
         )
         self.assertListEqual(
             [(1, 1), (2, 2), (3, 3)],
-            self.simple.join(
-                self.complex,
+            Enumerable([1, 2, 3])
+            .join(
+                Enumerable([{"value": 1}, {"value": 2}, {"value": 3}]),
                 inner_key=lambda x: x["value"],
                 result_func=lambda x: (x[0], x[1]["value"]),
             )
@@ -487,40 +651,37 @@ class TestFunctions(TestCase):
 
         self.assertListEqual(
             [(1, 1), (2, 2), (3, 3)],
-            self.complex.join(
-                self.complex, result_func=lambda x: (x[0]["value"], x[1]["value"])
+            Enumerable([{"value": 1}, {"value": 2}, {"value": 3}])
+            .join(
+                Enumerable([{"value": 1}, {"value": 2}, {"value": 3}]),
+                result_func=lambda x: (x[0]["value"], x[1]["value"]),
             )
             .order_by(lambda x: (x[0], x[1]))
             .to_list(),
         )
 
     def test_group_join(self):
-        self.assertRaises(TypeError, self.empty.group_join, [])
-        self.assertListEqual([], self.empty.group_join(self.empty).to_list())
+        self.assertRaises(TypeError, Enumerable.empty().group_join, [])
+        self.assertListEqual([], Enumerable().group_join(Enumerable()).to_list())
 
-        simple_empty_gj = self.simple.group_join(self.empty)
-        self.assertEqual(3, simple_empty_gj.count())
-        self.assertListEqual(
-            [(1, []), (2, []), (3, [])],
-            simple_empty_gj.select(lambda g: (g[0], g[1].to_list())).to_list(),
-        )
+        simple_empty_gj = Enumerable([1, 2, 3]).group_join(self.empty)
+        self.assertListEqual([], simple_empty_gj.to_list())
 
-        complex_simple_gj = self.complex.group_join(
-            self.simple, outer_key=lambda x: x["value"]
-        )
+        complex_simple_gj = Enumerable(
+            [{"value": 1}, {"value": 2}, {"value": 3}]
+        ).group_join(Enumerable([1, 2, 3, 3]), outer_key=lambda x: x["value"])
         self.assertListEqual(
-            [({"value": 1}, [1]), ({"value": 2}, [2]), ({"value": 3}, [3])],
+            [({"value": 1}, [1]), ({"value": 2}, [2]), ({"value": 3}, [3, 3])],
             complex_simple_gj.select(lambda g: (g[0], g[1].to_list())).to_list(),
         )
 
-        simple_gj = self.simple.group_join(
+        simple_gj = Enumerable([1, 2, 3]).group_join(
             Enumerable([2, 3]),
             result_func=lambda x: {"number": x[0], "collection": x[1].to_list()},
         )
-        self.assertEqual(3, simple_gj.count())
+        self.assertEqual(2, simple_gj.count())
         self.assertListEqual(
             [
-                {"number": 1, "collection": []},
                 {"number": 2, "collection": [2]},
                 {"number": 3, "collection": [3]},
             ],

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -313,8 +313,12 @@ class TestFunctions(TestCase):
 
     def test_concat(self):
         self.assertListEqual([], Enumerable().concat(Enumerable()).to_list())
-        self.assertListEqual([1, 2, 3], self.empty.concat(self.simple).to_list())
-        self.assertListEqual([1, 2, 3], self.simple.concat(Enumerable()).to_list())
+        self.assertListEqual(
+            [1, 2, 3], Enumerable().concat(Enumerable([1, 2, 3])).to_list()
+        )
+        self.assertListEqual(
+            [1, 2, 3], Enumerable([1, 2, 3]).concat(Enumerable()).to_list()
+        )
         self.assertListEqual(
             [1, 2, 3, 1, 2, 3],
             Enumerable([1, 2, 3])
@@ -815,7 +819,7 @@ class TestFunctions(TestCase):
 
     def test_skip_last(self):
         test = Enumerable([1, 2, 3, 4, 5]).skip_last(2)
-        self.assertListEqual(test.to_list(), [1, 2, 3])
+        self.assertListEqual([1, 2, 3], test.to_list())
 
         test = Enumerable(["one", "two", "three", "four", "five"]).skip(1).skip_last(1)
         self.assertListEqual(test.to_list(), ["two", "three", "four"])

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -33,11 +33,18 @@ class IssueTests(TestCase):
             for i in range(10):
                 yield i
 
-        low = Enumerable((i for i in range(10))).where(lambda x: x < 5)
-        high = Enumerable((i for i in range(10))).where(lambda x: x >= 5)
+        data = my_iter()
+        a = Enumerable(data)
+
+        low = a.where(lambda x: x < 5)
+        high = a.where(lambda x: x >= 5)
 
         self.assertListEqual(
             [(0, 5), (1, 6), (2, 7), (3, 8), (4, 9)], low.zip(high).to_list()
+        )
+
+        self.assertListEqual(
+            [(0, 5), (1, 6), (2, 7), (3, 8), (4, 9)], list(zip(low, high))
         )
 
     def test_generator_to_Enumerable(self):


### PR DESCRIPTION
**What changed**

- Added unit tests for issue #52 and issue #53 
- Added mutation for concat method so that when additional elements are added, this state is saved in the calling Enumerable object.
- Fixed broken methods that no longer worked because of this small change.