### PR TITLE
Rename "to_dict" to "to_dictionary"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,4 +76,4 @@ Once you have created an `Enumerable` instance, the LINQ methods will become ava
 45. [default_if_empty](/py-enumerable/default_if_empty)
 46. [single](/py-enumerable/single)
 47. [single_or_default](/py-enumerable/single-or-default)
-48. [to_dict](/py-enumerable/to-dict)
+48. [to_dictionary](/py-enumerable/to-dictionary)

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,3 +76,4 @@ Once you have created an `Enumerable` instance, the LINQ methods will become ava
 45. [default_if_empty](/py-enumerable/default_if_empty)
 46. [single](/py-enumerable/single)
 47. [single_or_default](/py-enumerable/single-or-default)
+48. [to_dict](/py-enumerable/to-dict)

--- a/docs/to-dict.md
+++ b/docs/to-dict.md
@@ -1,0 +1,45 @@
+## to_dict
+
+`to_dict()`
+
+Creates a `dict` from an `Enumerable`. This is not an executing function.
+
+**Parameters**
+
+__key__ : `lambda` function used for selecting the key for each item in a collection
+
+__value__: optional `lambda` function used for selecting the value for each item in a collection. Defaults to the item in the collection. 
+
+**Returns**
+
+A Python `dict` instance
+
+**Example**
+
+<pre><code>
+from py_linq import Enumerable
+
+collection = Enumerable([
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8]
+])
+
+collection.to_dict(lambda t: t[0], lambda t: t[1:])
+"""
+{
+    0: [1, 2],
+    3: [4, 5],
+    6: [7, 8]
+}
+"""
+
+collection.to_dict(lambda t: t[-1])
+"""
+{
+    2: [0, 1, 2],
+    5: [3, 4, 5],
+    8: [6, 7, 8]
+}
+"""
+</code></pre>

--- a/docs/to-dictionary.md
+++ b/docs/to-dictionary.md
@@ -1,6 +1,6 @@
-## to_dict
+## to_dictionary
 
-`to_dict()`
+`to_dictionary()`
 
 Creates a `dict` from an `Enumerable`. This is not an executing function.
 
@@ -25,7 +25,7 @@ collection = Enumerable([
     [6, 7, 8]
 ])
 
-collection.to_dict(lambda t: t[0], lambda t: t[1:])
+collection.to_dictionary(lambda t: t[0], lambda t: t[1:])
 """
 {
     0: [1, 2],
@@ -34,7 +34,7 @@ collection.to_dict(lambda t: t[0], lambda t: t[1:])
 }
 """
 
-collection.to_dict(lambda t: t[-1])
+collection.to_dictionary(lambda t: t[-1])
 """
 {
     2: [0, 1, 2],

--- a/py_linq/py_linq.py
+++ b/py_linq/py_linq.py
@@ -607,6 +607,18 @@ class Enumerable(object):
         """
         return TakeWhileEnumerable(Enumerable(iter(self)), predicate)
 
+    def to_dict(self, key=lambda x: x, value=lambda x: x):
+        """
+        Converts the enumerable into a dictionary
+        :param key: key selector to use to create dictionary keys
+        :param value: optional value selector to use to assign values to dictionary keys
+        :return: dict
+        """
+        result = {}
+        for i, e in enumerate(self):
+            result[key(e)] = value(e)
+        return result
+
     def zip(self, enumerable, func=lambda x: x):
         """
         Merges 2 Enumerables using the given function. If the 2 collections are of unequal length, then

--- a/py_linq/py_linq.py
+++ b/py_linq/py_linq.py
@@ -607,7 +607,7 @@ class Enumerable(object):
         """
         return TakeWhileEnumerable(Enumerable(iter(self)), predicate)
 
-    def to_dict(self, key=lambda x: x, value=lambda x: x):
+    def to_dictionary(self, key=lambda x: x, value=lambda x: x):
         """
         Converts the enumerable into a dictionary
         :param key: key selector to use to create dictionary keys

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -845,6 +845,17 @@ class TestFunctions(TestCase):
         test = Enumerable([]).skip_while(lambda x: x < 5)
         self.assertListEqual(test.to_list(), [])
 
+    def test_to_dict(self):
+        test = Enumerable(["ab", "bc", "cd", "de"]).to_dict(lambda t: t[0])
+        self.assertDictEqual(test, {"a": "ab", "b": "bc", "c": "cd", "d": "de"})
+
+        test = Enumerable([
+            [0, 1, 2],
+            [3, 4, 5],
+            [6, 7, 8]
+        ]).to_dict(lambda t: t[0], lambda t: t[1:])
+        self.assertDictEqual(test, {0: [1, 2], 3: [4, 5], 6: [7, 8]})
+
     def test_zip(self):
         test = Enumerable(["A", "B", "C", "D"]).zip(
             Enumerable(["x", "y"]), lambda t: "{0}{1}".format(t[0], t[1])

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -845,15 +845,15 @@ class TestFunctions(TestCase):
         test = Enumerable([]).skip_while(lambda x: x < 5)
         self.assertListEqual(test.to_list(), [])
 
-    def test_to_dict(self):
-        test = Enumerable(["ab", "bc", "cd", "de"]).to_dict(lambda t: t[0])
+    def test_to_dictionary(self):
+        test = Enumerable(["ab", "bc", "cd", "de"]).to_dictionary(lambda t: t[0])
         self.assertDictEqual(test, {"a": "ab", "b": "bc", "c": "cd", "d": "de"})
 
         test = Enumerable([
             [0, 1, 2],
             [3, 4, 5],
             [6, 7, 8]
-        ]).to_dict(lambda t: t[0], lambda t: t[1:])
+        ]).to_dictionary(lambda t: t[0], lambda t: t[1:])
         self.assertDictEqual(test, {0: [1, 2], 3: [4, 5], 6: [7, 8]})
 
     def test_zip(self):


### PR DESCRIPTION
## Summary

All instances of `to_dict` were replaced with `to_dictionary` to better match `System.Linq.Enumerable` method naming.