### PR TITLE
fixed bug in Enumerable.Any() 

### DIFF
--- a/py_linq/py_linq.py
+++ b/py_linq/py_linq.py
@@ -460,7 +460,10 @@ class Enumerable(object):
         :param predicate: condition to satisfy as lambda expression
         :return: boolean True or False
         """
-        return self.first_or_default(predicate) is not None
+        if predicate is None: predicate = lambda x: True
+        for item in self:
+            if predicate(item): return True
+        return False
 
     def intersect(self, enumerable: TEnumerable, key: Callable):
         """

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,6 +3,7 @@ import pytest
 
 
 _simple = [1, 2, 3]
+_simpleWithNone = [1,2,None,4]
 _complex = [{"value": 1}, {"value": 2}, {"value": 3}]
 
 _locations = [
@@ -30,6 +31,10 @@ def empty() -> Enumerable:
 @pytest.fixture
 def simple() -> Enumerable:
     return Enumerable(_simple)
+
+@pytest.fixture
+def simpleWithNone() -> Enumerable:
+    return Enumerable(_simpleWithNone)
 
 
 @pytest.fixture

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -13,6 +13,7 @@ import six
 import pytest
 from tests.fixtures import (
     _simple,
+    _simpleWithNone,
     _complex,
     _locations,
     simple_generator,
@@ -173,6 +174,7 @@ def test_element_at_error(enumerable: Callable, index: int, error: Exception) ->
         (Enumerable(_complex).any(), True),
         (Enumerable(_complex).any(lambda x: x["value"] < 1), False),
         (Enumerable(_complex).any(lambda x: x["value"] > 1), True),
+        (Enumerable(_simpleWithNone).any(lambda x: x==None), True),
         (Enumerable().contains(1), False),
         (Enumerable(_simple).contains(1), True),
         (Enumerable(_complex).select(lambda x: x["value"]).contains(1), True),


### PR DESCRIPTION
Enumerable.Any() failed to find 'None' values. I updated the function and updated unit tests to match.